### PR TITLE
fixed sequential unit tests execution

### DIFF
--- a/src/main/java/com/doctusoft/gwtmock/GWTMock.java
+++ b/src/main/java/com/doctusoft/gwtmock/GWTMock.java
@@ -36,7 +36,7 @@ public class GWTMock {
      */
     public static void reset() {
         // Implementation notes: There are no internal Mock events fired. All calls are made explicitly from this function.
-        RootPanel.get().clear();
+        RootPanel.detachWidgets();
         com.doctusoft.gwtmock.Document.reset();
         GWT.cleanCustomSuppliers();
     }

--- a/src/main/java/com/google/gwt/user/client/ui/RootPanel.java
+++ b/src/main/java/com/google/gwt/user/client/ui/RootPanel.java
@@ -232,7 +232,7 @@ public class RootPanel extends AbsolutePanel {
   }
 
   // Package-protected for use by unit tests. Do not call this method directly.
-  static void detachWidgets() {
+  public static void detachWidgets() {
     // When the window is closing, detach all widgets that need to be
     // cleaned up. This will cause all of their event listeners
     // to be unhooked, which will avoid potential memory leaks.

--- a/src/test/java/com/google/gwt/dom/client/TestElement.java
+++ b/src/test/java/com/google/gwt/dom/client/TestElement.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.doctusoft.gwtmock.Document;
+import com.doctusoft.gwtmock.GWTMock;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.RootPanel;
@@ -13,7 +14,7 @@ public class TestElement {
     
     @Before
     public void setup() {
-        RootPanel.get().clear();
+        GWTMock.reset();
     }
     
 	@Test

--- a/src/test/java/com/google/gwt/user/client/ui/TestButton.java
+++ b/src/test/java/com/google/gwt/user/client/ui/TestButton.java
@@ -1,8 +1,10 @@
 package com.google.gwt.user.client.ui;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.doctusoft.gwtmock.GWTMock;
 import com.google.gwt.dom.client.ButtonElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -10,6 +12,11 @@ import com.google.gwt.event.dom.client.ClickHandler;
 
 public class TestButton {
 	
+    @Before
+    public void setup() {
+        GWTMock.reset();
+    }
+    
 	@Test
 	public void testButtonClick() {
 		Button button = new Button("hello world");

--- a/src/test/java/com/google/gwt/user/client/ui/TestLabel.java
+++ b/src/test/java/com/google/gwt/user/client/ui/TestLabel.java
@@ -1,12 +1,19 @@
 package com.google.gwt.user.client.ui;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.doctusoft.gwtmock.Document;
+import com.doctusoft.gwtmock.GWTMock;
 
 public class TestLabel {
 	
+    @Before
+    public void setup() {
+       GWTMock.reset();
+    }
+    
 	@Test
 	public void testLabelPresent() {
 		RootPanel.get().add(new Label("hello world"));

--- a/src/test/java/com/google/gwt/user/client/ui/TestListBox.java
+++ b/src/test/java/com/google/gwt/user/client/ui/TestListBox.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.doctusoft.gwtmock.GWTMock;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.SelectElement;
@@ -17,7 +18,7 @@ public class TestListBox {
 
     @Before
     public void setup() {
-        //TODO GWTMock.reset();
+        GWTMock.reset();
     }
     
     @Test

--- a/src/test/java/com/google/gwt/user/client/ui/TestMenuBar.java
+++ b/src/test/java/com/google/gwt/user/client/ui/TestMenuBar.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.doctusoft.gwtmock.GWTMock;
 import com.google.gwt.core.client.impl.SchedulerImpl;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
@@ -15,7 +16,7 @@ public class TestMenuBar {
 
     @Before
     public void setup() {
-       // GWTMock.reset();
+       GWTMock.reset();
     }
     
     @Test


### PR DESCRIPTION
apparently root panel was left after previews execution and was attached to body that was already discarded.

Now all tests run fine (e.g. in maven and in Eclipse)
