### PR TITLE
Event.getEventTarget()

### DIFF
--- a/src/main/java/com/doctusoft/gwtmock/MockEventTargetElement.java
+++ b/src/main/java/com/doctusoft/gwtmock/MockEventTargetElement.java
@@ -1,0 +1,20 @@
+package com.doctusoft.gwtmock;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.EventTarget;
+
+public class MockEventTargetElement extends EventTarget {
+    
+    Element element;
+
+    public MockEventTargetElement(Element element) {
+        super();
+        this.element = element;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T cast() {
+        return (T) element;
+    }
+
+}

--- a/src/main/java/com/google/gwt/core/client/JavaScriptObject.java
+++ b/src/main/java/com/google/gwt/core/client/JavaScriptObject.java
@@ -116,7 +116,7 @@ public class JavaScriptObject {
    * @return this object as a different type
    */
   @SuppressWarnings("unchecked")
-  public final <T> T cast() {
+  public /*final*/ <T> T cast() {
     return (T) this;
   }
 

--- a/src/main/java/com/google/gwt/dom/client/DOMImpl.java
+++ b/src/main/java/com/google/gwt/dom/client/DOMImpl.java
@@ -189,7 +189,7 @@ public class DOMImpl {
 																				}-*/;
 	
 	public EventTarget eventGetTarget(NativeEvent evt) {
-		return null;
+		return evt.__eventTarget;
 	}
 	
 	public final String eventGetType(NativeEvent evt) {
@@ -203,7 +203,10 @@ public class DOMImpl {
 																						evt.keyCode = key;
 																						}-*/;
 	
-	public native void eventStopPropagation(NativeEvent evt) /*-{
+	public void eventStopPropagation(NativeEvent evt) {
+	    evt.__propagationStopped = true;
+	}
+	                                                                         /*-{
 																				evt.stopPropagation();
 																				}-*/;
 	

--- a/src/main/java/com/google/gwt/dom/client/Element.java
+++ b/src/main/java/com/google/gwt/dom/client/Element.java
@@ -22,14 +22,13 @@ import java.util.List;
 import java.util.Map;
 
 import net.htmlparser.jericho.Attribute;
-import net.htmlparser.jericho.CharacterReference;
-import net.htmlparser.jericho.EndTag;
 import net.htmlparser.jericho.Segment;
 import net.htmlparser.jericho.Source;
 import net.htmlparser.jericho.StartTag;
 import net.htmlparser.jericho.Tag;
 
 import com.doctusoft.gwtmock.Document;
+import com.doctusoft.gwtmock.MockEventTargetElement;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -49,13 +48,17 @@ public class Element extends Node {
 	protected Document document;
 	
 	public EventListener __listener = null;
+	
 	public int __eventBits = 0;
 	
-	public void fireEvent(Type<?> eventType) {
-		if ((__eventBits & Event.getTypeInt(eventType.getName())) != 0) {
-			__listener.onBrowserEvent(new Event(eventType.getName()));
-		}
-	}
+	// GwtMock. This method is not part of original GWT implementation.
+    public void fireEvent(Type<?> eventType) {
+        if ((__eventBits & Event.getTypeInt(eventType.getName())) != 0) {
+            Event event = new Event(eventType.getName());
+            event.__eventTarget = new MockEventTargetElement(this);
+            __listener.onBrowserEvent(event);
+        }
+    }
 	
 	protected String tagName = null;
 	

--- a/src/main/java/com/google/gwt/dom/client/NativeEvent.java
+++ b/src/main/java/com/google/gwt/dom/client/NativeEvent.java
@@ -25,6 +25,12 @@ public class NativeEvent extends JavaScriptObject {
 	
 	public String type;
 
+	// GwtMock
+    public boolean __propagationStopped;
+    
+    // GwtMock
+    public EventTarget __eventTarget;
+    
   /**
    * The left mouse button.
    */

--- a/src/test/java/com/doctusoft/gwtmock/driver/BrowserMock.java
+++ b/src/test/java/com/doctusoft/gwtmock/driver/BrowserMock.java
@@ -19,9 +19,14 @@ public class BrowserMock {
         DOMEventsMock.reset();
     }
 
-    public static void click(String paramString) {
-        Element element = GwtMockFinder.findElement(paramString);
-        assertFound(element, paramString);
+    /**
+     * @param elementLocator
+     *            Element Debug ID with (optional "gwt-debug-" prefix will be added)
+     *            or search criteria to find element in DOM. Example: "text=Action Two"
+     */
+    public static void click(String elementLocator) {
+        Element element = GwtMockFinder.findElement(elementLocator);
+        assertFound(element, elementLocator);
         click(element);
     }
 
@@ -38,9 +43,9 @@ public class BrowserMock {
         browserExit();
     }
 
-    public static void type(String paramString, String value) {
-        Element element = GwtMockFinder.findElement(paramString);
-        assertFound(element, paramString);
+    public static void type(String elementLocator, String value) {
+        Element element = GwtMockFinder.findElement(elementLocator);
+        assertFound(element, elementLocator);
         type(element, value);
     }
 
@@ -51,9 +56,9 @@ public class BrowserMock {
         browserExit();
     }
 
-    public static void setValue(String paramString, String value) {
-        Element element = GwtMockFinder.findElement(paramString);
-        assertFound(element, paramString);
+    public static void setValue(String elementLocator, String value) {
+        Element element = GwtMockFinder.findElement(elementLocator);
+        assertFound(element, elementLocator);
         setValue(element, value);
     }
 
@@ -84,8 +89,8 @@ public class BrowserMock {
     }
 
     // --- asserts
-    public static boolean isElementPresent(String paramString) {
-        Element element = GwtMockFinder.findElement(paramString);
+    public static boolean isElementPresent(String elementIdentifier) {
+        Element element = GwtMockFinder.findElement(elementIdentifier);
         return element != null;
     }
 
@@ -103,31 +108,31 @@ public class BrowserMock {
         }
     }
 
-    public static boolean isDisplayed(String paramString) {
-        return isDisplayed(GwtMockFinder.findElement(paramString));
+    public static boolean isDisplayed(String elementLocator) {
+        return isDisplayed(GwtMockFinder.findElement(elementLocator));
     }
 
-    public static void assertPresent(String locator) {
-        boolean present = isElementPresent(locator);
+    public static void assertPresent(String elementLocator) {
+        boolean present = isElementPresent(elementLocator);
         if (!present) {
             System.out.println(Document.get().getBody().getInnerHTML());
         }
-        Assert.assertTrue(locator + " should exists", present);
+        Assert.assertTrue(elementLocator + " should exists", present);
     }
 
-    public static void assertNotPresent(String locator) {
-        boolean present = isElementPresent(locator);
+    public static void assertNotPresent(String elementLocator) {
+        boolean present = isElementPresent(elementLocator);
         if (present) {
             System.out.println(Document.get().getBody().getInnerHTML());
         }
-        Assert.assertFalse(locator + " should not be present", present);
+        Assert.assertFalse(elementLocator + " should not be present", present);
     }
 
-    public static void assertVisible(String locator) {
-        Assert.assertTrue(locator + " should be visible", isDisplayed(locator));
+    public static void assertVisible(String elementLocator) {
+        Assert.assertTrue(elementLocator + " should be visible", isDisplayed(elementLocator));
     }
 
-    public static void assertNotVisible(String locator) {
-        Assert.assertFalse(locator + " should not be visible", isDisplayed(locator));
+    public static void assertNotVisible(String elementLocator) {
+        Assert.assertFalse(elementLocator + " should not be visible", isDisplayed(elementLocator));
     }
 }

--- a/src/test/java/com/doctusoft/gwtmock/driver/DOMEventsMock.java
+++ b/src/test/java/com/doctusoft/gwtmock/driver/DOMEventsMock.java
@@ -1,5 +1,6 @@
 package com.doctusoft.gwtmock.driver;
 
+import com.doctusoft.gwtmock.MockEventTargetElement;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.event.dom.client.BlurEvent;
@@ -95,20 +96,20 @@ class DOMEventsMock {
      */
     public static void fireEventBubbling(Element element, Type<?> eventType) {
         Event event = new Event(eventType.getName());
-        // event.__eventTarget = new EventTarget.MockEventTargetElement(element);
+        event.__eventTarget = new MockEventTargetElement(element);
         Element eventTarget = element;
-        // while (!event.isPropagationStopped()) {
-        Element currentEventTarget = getFirstAncestorWithListener(eventType, eventTarget);
-        if (currentEventTarget == null) {
-            return;
-        }
+        while (!event.__propagationStopped) {
+            Element currentEventTarget = getFirstAncestorWithListener(eventType, eventTarget);
+            if (currentEventTarget == null) {
+                return;
+            }
 
-        getEventListener(eventType, currentEventTarget).onBrowserEvent(event);
-        //  continue if event.stopPropagation() was not called.
-        if (currentEventTarget.getParentNode() != null) {
-            eventTarget = currentEventTarget.getParentNode().cast();
+            getEventListener(eventType, currentEventTarget).onBrowserEvent(event);
+            //  will continue to parent while event.stopPropagation() was not called.
+            if (currentEventTarget.getParentNode() != null) {
+                eventTarget = currentEventTarget.getParentNode().cast();
+            }
         }
-        // }
     }
 
     private static Element getFirstAncestorWithListener(Type<?> eventType, Element curElem) {

--- a/src/test/java/com/doctusoft/gwtmock/driver/GwtMockFinder.java
+++ b/src/test/java/com/doctusoft/gwtmock/driver/GwtMockFinder.java
@@ -29,12 +29,12 @@ public abstract class GwtMockFinder {
         }
     }
 
-    public static Element findElement(String paramString) {
+    public static Element findElement(String elementLocator) {
         Element element = null;
 
-        String[] prams = paramString.split("=");
+        String[] prams = elementLocator.split("=");
         if (prams.length > 1) {
-            final String text = paramString.substring(paramString.indexOf('=') + 1);
+            final String text = elementLocator.substring(elementLocator.indexOf('=') + 1);
             GwtMockFinder finder;
             if (prams[0].equals("text")) {
                 finder = new GwtMockFinder() {
@@ -67,7 +67,7 @@ public abstract class GwtMockFinder {
             }
             element = find(Document.get().getBody().getChildElements(), finder);
         } else {
-            element = Document.get().getElementById(by(paramString));
+            element = Document.get().getElementById(by(elementLocator));
         }
         return element;
     }

--- a/src/test/java/com/google/gwt/user/client/ui/TestMenuBar.java
+++ b/src/test/java/com/google/gwt/user/client/ui/TestMenuBar.java
@@ -5,18 +5,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.doctusoft.gwtmock.GWTMock;
-import com.google.gwt.core.client.impl.SchedulerImpl;
+import com.doctusoft.gwtmock.driver.BrowserMock;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.user.client.Command;
 
 public class TestMenuBar {
 
     @Before
     public void setup() {
-       GWTMock.reset();
+        BrowserMock.setUp();
     }
     
     @Test
@@ -32,10 +30,8 @@ public class TestMenuBar {
         Element element =  Document.get().getElementById("gwt-debug-menuItemOne");
         Assert.assertNotNull("Menu Item created", element);
     
-        //TODO Events tests will be added later once the decision will be made on where we have a driver class
-        //DOM fireEventBubbling(element, ClickEvent.getType());
-        //SchedulerImpl.INSTANCE.executeDeferredCommands();
-        //Mockito.verify(command).execute();
+        BrowserMock.click(element);
+        Mockito.verify(command).execute();
     }
     
 }

--- a/src/test/java/com/google/gwt/user/client/ui/events/TestEventBubbling.java
+++ b/src/test/java/com/google/gwt/user/client/ui/events/TestEventBubbling.java
@@ -1,7 +1,6 @@
 package com.google.gwt.user.client.ui.events;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;

--- a/src/test/java/com/google/gwt/user/client/ui/events/TestEventBubbling.java
+++ b/src/test/java/com/google/gwt/user/client/ui/events/TestEventBubbling.java
@@ -22,7 +22,6 @@ public class TestEventBubbling {
     }
 
     @Test
-    @Ignore
     public void testClickEventBubbling() {
         Label field1 = new Label();
         field1.ensureDebugId("label1");


### PR DESCRIPTION
implemented EventTarget for for events simulation, Tested with MenuItem and TestEventBubbling

new class MockEventTargetElement is added in package com.doctusoft.gwtmock; 
Another alternative to move this class  as inner class to EventTarget.
This class added so that hierarchy of Element itself will not be changed and Element can be used as EventTarget.

The name MockEventTargetElement  of the class can be improved.
