### PR TITLE
add alt property instead of setAlt

### DIFF
--- a/src/main/java/com/google/gwt/user/client/ui/Image.java
+++ b/src/main/java/com/google/gwt/user/client/ui/Image.java
@@ -839,7 +839,9 @@ public class Image extends Widget implements SourcesLoadEvents, HasLoadHandlers,
    * @param altText the alternate text to set to
    */
   public void setAltText(String altText) {
-    state.getImageElement(this).setAlt(altText);
+      //instead of calling setAlt for ImageElement just adding alt property
+      //state.getImageElement(this).setAlt(altText);
+      state.getImageElement(this).setPropertyString("alt", altText);
   }
 
   /**


### PR DESCRIPTION
On setAlt for Image element fails with  java.lang.NoSuchMethodError: com.google.gwt.user.client.ui.TextBox.getElement() as tries to call native setAlt element. Adding alt property to skip native function call.